### PR TITLE
use annotated file A for geometries and datetime instead of HDF5 meta…

### DIFF
--- a/examples/winnip_31604_12061_004_120717_L090_CX_07/winnip_31604_12061_004_120717_L090_CX_07.json
+++ b/examples/winnip_31604_12061_004_120717_L090_CX_07/winnip_31604_12061_004_120717_L090_CX_07.json
@@ -4,54 +4,40 @@
   "id": "winnip_31604_12061_004_120717_L090_CX_07",
   "properties": {
     "proj:epsg": 4326,
-    "sat:absolute_orbit": 12061,
-    "datetime": "2012-07-17T14:39:45.732157Z"
+    "datetime": "2012-07-17T14:36:47Z"
   },
   "geometry": {
     "type": "Polygon",
     "coordinates": [
       [
         [
-          -97.683,
-          49.486
+          -98.6699,
+          49.846
         ],
         [
-          -97.908,
-          49.343
+          -98.4496,
+          49.9867
         ],
         [
-          -98.669,
-          49.847
+          -97.9093,
+          49.3426
         ],
         [
-          -98.443,
-          49.991
+          -97.6891,
+          49.4819
         ],
         [
-          -97.683,
-          49.486
+          -98.6699,
+          49.846
         ]
       ]
     ]
   },
   "links": [
     {
-      "rel": "root",
-      "href": "../collection.json",
-      "type": "application/json",
-      "title": "Simulated NISAR"
-    },
-    {
-      "rel": "collection",
-      "href": "../collection.json",
-      "type": "application/json",
-      "title": "Simulated NISAR"
-    },
-    {
-      "rel": "parent",
-      "href": "../collection.json",
-      "type": "application/json",
-      "title": "Simulated NISAR"
+      "rel": "self",
+      "href": "/Users/emiletenezakis/devseed/nisar-sim/winnip_31604_12061_004_120717_L090_CX_07.json",
+      "type": "application/json"
     }
   ],
   "assets": {
@@ -480,14 +466,12 @@
     }
   },
   "bbox": [
-    -98.669,
-    49.343,
-    -97.683,
-    49.991
+    -97.9093,
+    49.3426,
+    -98.4496,
+    49.9867
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
-  ],
-  "collection": "nisar-sim"
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+  ]
 }

--- a/src/stactools/nisar_sim/commands.py
+++ b/src/stactools/nisar_sim/commands.py
@@ -53,8 +53,14 @@ def create_nisarsim_command(cli: Group) -> Command:
         type=click.Choice(["129", "138", "143"]),
         help="set of numbers indicating the item's nmode ('129','138','143')",
     )
+    @click.option(
+        "--sat-extension",
+        default=False,
+        type=bool,
+        help="Whether to include the SAT extension. Requires that the HDF5 file is present in `product_path`.",
+    )
     def create_item_command(
-        source: str, destination: str, dither: str, nmode: str
+        source: str, destination: str, dither: str, nmode: str, sat_extension: bool
     ) -> None:
         """Creates a STAC Item
 

--- a/src/stactools/nisar_sim/commands.py
+++ b/src/stactools/nisar_sim/commands.py
@@ -53,14 +53,8 @@ def create_nisarsim_command(cli: Group) -> Command:
         type=click.Choice(["129", "138", "143"]),
         help="set of numbers indicating the item's nmode ('129','138','143')",
     )
-    @click.option(
-        "--sat-extension",
-        default=False,
-        type=bool,
-        help="Whether to include the SAT extension. Requires that the HDF5 file is present in `product_path`.",
-    )
     def create_item_command(
-        source: str, destination: str, dither: str, nmode: str, sat_extension: bool
+        source: str, destination: str, dither: str, nmode: str
     ) -> None:
         """Creates a STAC Item
 

--- a/src/stactools/nisar_sim/metadata.py
+++ b/src/stactools/nisar_sim/metadata.py
@@ -117,7 +117,7 @@ class Metadata:
             # using the A file for geometries. A and B are approximately similar. 
             
             def _get_rounded_coord(k) -> float:
-                return np.round(float(self.ann_metadata.metadata_a[k]), 4)
+                return np.round(float(self.ann_metadata.metadata_a[k]), 3)
             
             
             bbox = [_get_rounded_coord(k) for k in ["Approximate_Lower_Left_Longitude", "Approximate_Lower_Left_Latitude", "Approximate_Upper_Right_Longitude", "Approximate_Upper_Right_Latitude"]]

--- a/src/stactools/nisar_sim/metadata.py
+++ b/src/stactools/nisar_sim/metadata.py
@@ -8,9 +8,6 @@ import h5py
 import numpy as np
 import pystac
 from pystac.extensions.sat import SatExtension
-from pystac.utils import str_to_datetime
-from shapely.geometry import mapping
-from shapely.wkt import loads
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
@@ -115,7 +112,7 @@ class Metadata:
         def _get_geometries_from_ann_metadata() -> Tuple[List[float], Dict[str, Any]]:
             # using the A file for geometries. A and B are approximately similar.
 
-            def _get_rounded_coord(k) -> float:
+            def _get_rounded_coord(k: str) -> Any:
                 return np.round(float(self.ann_metadata.metadata_a[k]), 3)
 
             bbox = [

--- a/src/stactools/nisar_sim/metadata.py
+++ b/src/stactools/nisar_sim/metadata.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TypeVar
 
 import h5py
+import numpy as np
 import pystac
 from pystac.extensions.sat import SatExtension
 from pystac.utils import str_to_datetime
 from shapely.geometry import mapping
 from shapely.wkt import loads
-import numpy as np
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
@@ -107,45 +107,89 @@ class AnnotatedMetadata:
 
 class Metadata:
     def __init__(self, href: str, id: str, h5_metadata: Any, ann_metadata: Any) -> None:
-
         self.href = href
         self.base_id = "_".join(id.split("_")[:-2])
         self.h5_metadata = h5_metadata
         self.ann_metadata = ann_metadata
-        
+
         def _get_geometries_from_ann_metadata() -> Tuple[List[float], Dict[str, Any]]:
-            # using the A file for geometries. A and B are approximately similar. 
-            
+            # using the A file for geometries. A and B are approximately similar.
+
             def _get_rounded_coord(k) -> float:
                 return np.round(float(self.ann_metadata.metadata_a[k]), 3)
-            
-            
-            bbox = [_get_rounded_coord(k) for k in ["Approximate_Lower_Left_Longitude", "Approximate_Lower_Left_Latitude", "Approximate_Upper_Right_Longitude", "Approximate_Upper_Right_Latitude"]]
-            
-            polygon_coords = [
-                [_get_rounded_coord(k) for k in ["Approximate_Upper_Left_Longitude", "Approximate_Upper_Left_Latitude"]],
-                [_get_rounded_coord(k) for k in ["Approximate_Upper_Right_Longitude", "Approximate_Upper_Right_Latitude"]],
-                [_get_rounded_coord(k) for k in ["Approximate_Lower_Left_Longitude", "Approximate_Lower_Left_Latitude"]],
-                [_get_rounded_coord(k) for k in ["Approximate_Lower_Right_Longitude", "Approximate_Lower_Right_Latitude"]],
-                [_get_rounded_coord(k) for k in ["Approximate_Upper_Left_Longitude", "Approximate_Upper_Left_Latitude"]],                
+
+            bbox = [
+                _get_rounded_coord(k)
+                for k in [
+                    "Approximate_Lower_Left_Longitude",
+                    "Approximate_Lower_Left_Latitude",
+                    "Approximate_Upper_Right_Longitude",
+                    "Approximate_Upper_Right_Latitude",
+                ]
             ]
-            
-            geometry = {'type': 'Polygon', 'coordinates': [polygon_coords]}
+
+            polygon_coords = [
+                [
+                    _get_rounded_coord(k)
+                    for k in [
+                        "Approximate_Upper_Left_Longitude",
+                        "Approximate_Upper_Left_Latitude",
+                    ]
+                ],
+                [
+                    _get_rounded_coord(k)
+                    for k in [
+                        "Approximate_Upper_Right_Longitude",
+                        "Approximate_Upper_Right_Latitude",
+                    ]
+                ],
+                [
+                    _get_rounded_coord(k)
+                    for k in [
+                        "Approximate_Lower_Left_Longitude",
+                        "Approximate_Lower_Left_Latitude",
+                    ]
+                ],
+                [
+                    _get_rounded_coord(k)
+                    for k in [
+                        "Approximate_Lower_Right_Longitude",
+                        "Approximate_Lower_Right_Latitude",
+                    ]
+                ],
+                [
+                    _get_rounded_coord(k)
+                    for k in [
+                        "Approximate_Upper_Left_Longitude",
+                        "Approximate_Upper_Left_Latitude",
+                    ]
+                ],
+            ]
+
+            geometry = {"type": "Polygon", "coordinates": [polygon_coords]}
             return (bbox, geometry)
-        
+
         self.bbox, self.geometry = _get_geometries_from_ann_metadata()
 
     @property
     def start_datetime(self) -> datetime:
-        return datetime.strptime(self.ann_metadata.metadata_a['Start_Time_of_Acquisition'], "%d-%b-%Y %H:%M:%S %Z")
-        
+        return datetime.strptime(
+            self.ann_metadata.metadata_a["Start_Time_of_Acquisition"],
+            "%d-%b-%Y %H:%M:%S %Z",
+        )
+
     @property
     def end_datetime(self) -> datetime:
-        return datetime.strptime(self.ann_metadata.metadata_a['Stop_Time_of_Acquisition'], "%d-%b-%Y %H:%M:%S %Z")
-        
+        return datetime.strptime(
+            self.ann_metadata.metadata_a["Stop_Time_of_Acquisition"],
+            "%d-%b-%Y %H:%M:%S %Z",
+        )
+
     @property
     def get_datetime(self) -> datetime:
-        return datetime.strptime(self.ann_metadata.metadata_a['Date_of_Acquisition'], "%d-%b-%Y %H:%M:%S %Z")
+        return datetime.strptime(
+            self.ann_metadata.metadata_a["Date_of_Acquisition"], "%d-%b-%Y %H:%M:%S %Z"
+        )
 
     @property
     def inventory(self) -> List[str]:

--- a/src/stactools/nisar_sim/stac.py
+++ b/src/stactools/nisar_sim/stac.py
@@ -72,7 +72,8 @@ def create_item(
             D: Dithered without gaps
         nmode (str): set of numbers associated with a specific center frequency,
             bandwidth, and polarization ("129","138","143")
-        sat_extension (bool): Whether to include the SAT extension. Requires that the HDF5 file is present in `product_path`.
+        sat_extension (bool): Whether to include the SAT extension.
+        Requires that the HDF5 file is present in `product_path`.
 
     Returns:
         Item: STAC Item object
@@ -113,6 +114,9 @@ def create_item(
     # SAT extension
     if sat_extension:
         sat = SatExtension.ext(item, add_if_missing=True)
-        fill_sat_properties(sat, h5_data.metadata)
+        if h5_data is not None:
+            fill_sat_properties(sat, h5_data.metadata)
+        else:
+            raise ValueError("HDF5 data not found. Cannot add SAT extension.")
 
     return item

--- a/src/stactools/nisar_sim/stac.py
+++ b/src/stactools/nisar_sim/stac.py
@@ -59,7 +59,9 @@ def create_collection() -> Collection:
     return collection
 
 
-def create_item(product_path: str, dither: str, nmode: str, sat_extension: bool = False) -> Item:
+def create_item(
+    product_path: str, dither: str, nmode: str, sat_extension: bool = False
+) -> Item:
     """Create a STAC Item
 
     Args:

--- a/src/stactools/nisar_sim/stac.py
+++ b/src/stactools/nisar_sim/stac.py
@@ -59,7 +59,7 @@ def create_collection() -> Collection:
     return collection
 
 
-def create_item(product_path: str, dither: str, nmode: str) -> Item:
+def create_item(product_path: str, dither: str, nmode: str, sat_extension: bool = False) -> Item:
     """Create a STAC Item
 
     Args:
@@ -70,12 +70,13 @@ def create_item(product_path: str, dither: str, nmode: str) -> Item:
             D: Dithered without gaps
         nmode (str): set of numbers associated with a specific center frequency,
             bandwidth, and polarization ("129","138","143")
+        sat_extension (bool): Whether to include the SAT extension. Requires that the HDF5 file is present in `product_path`.
 
     Returns:
         Item: STAC Item object
     """
     metalinks = MetadataLinks(product_path, dither, nmode)
-    h5_data = HDF5Metadata(metalinks.h5_href)
+    h5_data = HDF5Metadata(metalinks.h5_href) if sat_extension else None
     ann_data = AnnotatedMetadata(metalinks.ann_a_href, metalinks.ann_b_href)
     metadata = Metadata(product_path, metalinks.id, h5_data, ann_data)
 
@@ -108,7 +109,8 @@ def create_item(product_path: str, dither: str, nmode: str) -> Item:
             item.add_asset(asset_name(_file), asset)
 
     # SAT extension
-    sat = SatExtension.ext(item, add_if_missing=True)
-    fill_sat_properties(sat, h5_data.metadata)
+    if sat_extension:
+        sat = SatExtension.ext(item, add_if_missing=True)
+        fill_sat_properties(sat, h5_data.metadata)
 
     return item


### PR DESCRIPTION
- Use annotated file A for datetimes instead of HDF5 metadata
- Use annotated file A for geometries instead of HDF5 metadata
- Make the SAT extension optional. 

This branch doesn't have the last commit of `main`, I need to update that. @jjfrench could you comment on the general approach to get the geometries ? 

I'll clean up the minor things tomorrow. Thanks !